### PR TITLE
feat(m6): implement deterministic STIX/MISP exports in basic triage

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,6 @@ Forensic Triage currently mocked capabilities:
 - [ ] imphash / TLSH / ssdeep generation.
 - [ ] YARA / YARA-X scanning integration.
 - [ ] Authenticode/X509 verification.
-- [ ] STIX/MISP export.
 - [ ] External dynamic sandbox connector (e.g. Cuckoo).
 
 ## Documentation Index

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,6 +13,7 @@ A clean-slate, modular, and secure workbench for data operations — successor t
 - [C Implementation Master Plan](parity/c-implementation-master-plan.md)
 - [Forensic Triage Progress](parity/forensic-triage-progress.md)
 - [C3 Contracts](parity/c3-operation-compatibility-contracts.md)
+- [M6 STIX/MISP Mapping](parity/m6-stix-misp-mapping.md)
 - [M5 Merge Readiness](parity/m5-merge-readiness.md)
 - [CSP Checklist](security/csp-checklist.md)
 - [Phase A Definition of Done](phase-a-definition-of-done.md)

--- a/docs/parity/c-implementation-master-plan.md
+++ b/docs/parity/c-implementation-master-plan.md
@@ -125,7 +125,9 @@ Deliver a complete, auditable, and operationally useful C-track:
 3. `[DONE]` baseline triage verdict module with scored findings and recommendations.
 4. `[DONE]` safety constraints baseline (bounded IOC/segment extraction controls).
 5. `[IN-PROGRESS]` contract tests + golden fixtures for known malware-like samples.
-6. `[IN-PROGRESS]` production integrations currently mocked (ZIP password pipeline, YARA, STIX/MISP, dynamic sandbox connector).
+6. `[IN-PROGRESS]` production integrations:
+   - `[DONE]` deterministic STIX/MISP export payloads in `forensic.basicTriage`
+   - `[PLANNED]` ZIP password pipeline, YARA scanning, dynamic sandbox connector
 7. `[PLANNED]` advanced triage add-ons: full `imphash`, TLSH/ssdeep adapters, broader binary format support.
 
 ## C3 Contract and Determinism Program

--- a/docs/parity/m6-stix-misp-mapping.md
+++ b/docs/parity/m6-stix-misp-mapping.md
@@ -1,0 +1,28 @@
+# M6 STIX/MISP Mapping
+
+Status: in progress
+
+This document defines deterministic mapping from `forensic.basicTriage` IOC fields to export artifacts.
+
+## STIX 2.1 bundle mapping
+
+- `iocs.urls[]` -> `indicator` with pattern `[url:value = '<value>']`
+- `iocs.domains[]` -> `indicator` with pattern `[domain-name:value = '<value>']`
+- `iocs.ipv4[]` -> `indicator` with pattern `[ipv4-addr:value = '<value>']`
+- `iocs.ipv6[]` -> `indicator` with pattern `[ipv6-addr:value = '<value>']`
+- `iocs.emails[]` -> `indicator` with pattern `[email-addr:value = '<value>']`
+- `iocs.cves[]` -> `indicator` with pattern `[vulnerability:name = '<value>']`
+
+Determinism rules:
+- `bundle.id` and `indicator.id` are generated via stable non-random hash.
+- `created`, `modified`, `valid_from` use fixed epoch for reproducibility.
+
+## MISP event mapping
+
+- `urls` -> `type: url`, `category: Network activity`
+- `domains` -> `type: domain`, `category: Network activity`
+- `ipv4/ipv6` -> `type: ip-dst`, `category: Network activity`
+- `emails` -> `type: email-src`, `category: Payload delivery`
+- `cves` -> `type: vulnerability`, `category: External analysis`
+
+Event metadata is deterministic (`date: 1970-01-01`) to preserve repeatable snapshots in tests.

--- a/packages/plugins-standard/test/basicTriage.test.ts
+++ b/packages/plugins-standard/test/basicTriage.test.ts
@@ -24,6 +24,10 @@ describe("forensic basic triage", () => {
       score: { riskScoreNorm: number; verdict: string; reasons: string[] };
       findings: Array<{ id: string }>;
       mockedCapabilities: string[];
+      exports: {
+        stixBundle: { type: string; objects: Array<Record<string, unknown>> };
+        mispEvent: { Event: { Attribute: Array<{ type: string; value: string }> } };
+      };
       recommendations: string[];
       preTriage: { iocs: { cves: string[] } };
     };
@@ -33,7 +37,16 @@ describe("forensic basic triage", () => {
     expect(report.findings.length).toBeGreaterThan(0);
     expect(report.preTriage.iocs.cves).toEqual(["CVE-2024-12345"]);
     expect(report.mockedCapabilities).not.toContain("md5_digest_generation");
+    expect(report.mockedCapabilities).not.toContain("stix_export");
+    expect(report.mockedCapabilities).not.toContain("misp_export");
     expect(report.mockedCapabilities).toContain("dynamic_sandbox_integration_cuckoo");
+    expect(report.exports.stixBundle.type).toBe("bundle");
+    expect(report.exports.stixBundle.objects.length).toBeGreaterThan(0);
+    expect(
+      report.exports.mispEvent.Event.Attribute.some(
+        (attr) => attr.type === "vulnerability" && attr.value === "CVE-2024-12345"
+      )
+    ).toBe(true);
     expect(report.recommendations.length).toBeGreaterThan(0);
   });
 


### PR DESCRIPTION
## Summary
- adds real deterministic STIX 2.1 bundle and MISP event exports to `forensic.basicTriage`
- removes STIX/MISP from mocked capability list
- adds mapping documentation and tests
- updates C-track plan status for M6 progress

## Validation
- [x] `pnpm c3:contracts`
- [x] `pnpm c3:testgen`
- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm --filter @cybermasterchef/plugins-standard test -- test/basicTriage.test.ts`
- [x] `pnpm build`
- [x] `pnpm c3:validate`