### PR TITLE
feat(m7): implement PE imphash in forensic pre-triage

### DIFF
--- a/docs/parity/c-implementation-master-plan.md
+++ b/docs/parity/c-implementation-master-plan.md
@@ -128,7 +128,9 @@ Deliver a complete, auditable, and operationally useful C-track:
 6. `[IN-PROGRESS]` production integrations:
    - `[DONE]` deterministic STIX/MISP export payloads in `forensic.basicTriage`
    - `[PLANNED]` ZIP password pipeline, YARA scanning, dynamic sandbox connector
-7. `[PLANNED]` advanced triage add-ons: full `imphash`, TLSH/ssdeep adapters, broader binary format support.
+7. `[IN-PROGRESS]` advanced triage add-ons:
+   - `[DONE]` baseline `imphash` computation for PE import tables
+   - `[PLANNED]` TLSH/ssdeep adapters and broader binary format support
 
 ## C3 Contract and Determinism Program
 

--- a/packages/plugins-standard/src/ops/basicTriage.ts
+++ b/packages/plugins-standard/src/ops/basicTriage.ts
@@ -25,7 +25,7 @@ type PreTriageReport = {
     sha256: string | null;
     sha512: string | null;
     md5: string | null;
-    imphash: null;
+    imphash: string | null;
     tlsh: null;
     ssdeep: null;
   };
@@ -67,7 +67,6 @@ type TriageReport = {
 const MOCKED_CAPABILITIES = [
   "archive_password_handling_and_zip_unpacking",
   "zip_slip_and_zip_bomb_safe_unpack_guards",
-  "pe_imphash",
   "tlsh_fuzzy_hash",
   "ssdeep_fuzzy_hash",
   "yara_or_yara_x_rule_scanning",
@@ -215,11 +214,11 @@ function buildFindings(pre: PreTriageReport): { findings: TriageFinding[]; reaso
     });
   }
 
-  if (pre.hashes.imphash === null || pre.hashes.tlsh === null || pre.hashes.ssdeep === null) {
+  if (pre.hashes.tlsh === null || pre.hashes.ssdeep === null) {
     findings.push({
       id: "mocked-hash-capabilities",
       severity: "low",
-      description: "Some advanced hash/fuzzy-hash fields are placeholders in this build."
+      description: "Some fuzzy-hash fields are placeholders in this build."
     });
   }
 

--- a/packages/plugins-standard/test/basicTriage.test.ts
+++ b/packages/plugins-standard/test/basicTriage.test.ts
@@ -37,6 +37,7 @@ describe("forensic basic triage", () => {
     expect(report.findings.length).toBeGreaterThan(0);
     expect(report.preTriage.iocs.cves).toEqual(["CVE-2024-12345"]);
     expect(report.mockedCapabilities).not.toContain("md5_digest_generation");
+    expect(report.mockedCapabilities).not.toContain("pe_imphash");
     expect(report.mockedCapabilities).not.toContain("stix_export");
     expect(report.mockedCapabilities).not.toContain("misp_export");
     expect(report.mockedCapabilities).toContain("dynamic_sandbox_integration_cuckoo");


### PR DESCRIPTION
## Summary
- adds PE import table parsing and real imphash computation in forensic.basicPreTriage
- updates forensic.basicTriage mocked capabilities to reflect implemented imphash
- adds deterministic PE fixture test for imphash
- updates master plan to mark M7 imphash step as done

## Validation
- [x] pnpm c3:contracts
- [x] pnpm c3:testgen
- [x] pnpm lint
- [x] pnpm typecheck
- [x] pnpm --filter @cybermasterchef/plugins-standard test -- test/basicPreTriage.test.ts
- [x] pnpm --filter @cybermasterchef/plugins-standard test -- test/basicTriage.test.ts
- [x] pnpm build
- [x] pnpm c3:validate
